### PR TITLE
Add tests and seasons argument

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pandas
 tqdm
 beautifulsoup4
+pytest

--- a/scraper/sports_reference.py
+++ b/scraper/sports_reference.py
@@ -128,10 +128,18 @@ def _fetch_roster_csv(
     )
 
 
-def fetch_rosters() -> None:
-    """Scrape rosters and save them to ``data/master_raw.csv``."""
+def fetch_rosters(seasons: Optional[Iterable[int]] = None) -> None:
+    """Scrape rosters and save them to ``data/master_raw.csv``.
 
-    seasons = list(range(2017, 2022))
+    Parameters
+    ----------
+    seasons : Iterable[int], optional
+        Specific ending years of seasons to scrape. If ``None`` (default),
+        seasons 2016-17 through 2020-21 are scraped.
+    """
+
+    if seasons is None:
+        seasons = list(range(2017, 2022))
     sports = ["men", "women", "football"]
 
     session = requests.Session()

--- a/tests/test_roster_scraper.py
+++ b/tests/test_roster_scraper.py
@@ -1,0 +1,14 @@
+import os
+import pandas as pd
+from scraper.sports_reference import fetch_rosters
+
+def test_fetch_rosters(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    fetch_rosters(seasons=[2019])
+    csv = tmp_path / "data" / "master_raw.csv"
+    assert csv.exists()
+    df = pd.read_csv(csv)
+    assert len(df) >= 5000
+    expected_cols = ["season", "sport", "school", "player", "position", "class"]
+    for col in expected_cols:
+        assert col in df.columns


### PR DESCRIPTION
## Summary
- accept optional `seasons` argument in `fetch_rosters`
- add basic roster scraping test using season 2019
- include pytest in requirements

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*
- `pytest -q` *(fails: command not found)*