### PR TITLE
Implement team slug fetcher

### DIFF
--- a/tests/test_slug_fetch.py
+++ b/tests/test_slug_fetch.py
@@ -1,0 +1,8 @@
+import pytest
+from scraper.sports_reference import get_team_slugs
+
+
+def test_get_team_slugs_counts():
+    assert len(get_team_slugs("men", 2019)) >= 350
+    assert len(get_team_slugs("women", 2019)) >= 350
+    assert len(get_team_slugs("football", 2019)) >= 128


### PR DESCRIPTION
## Summary
- add `get_team_slugs` to obtain school slugs from index pages
- test that slug fetcher returns a large number of teams

## Testing
- `pytest -q` *(fails: command not found)*